### PR TITLE
fix ambient access, add composable annotation

### DIFF
--- a/router/src/main/java/com/github/zsoltk/compose/router/Router.kt
+++ b/router/src/main/java/com/github/zsoltk/compose/router/Router.kt
@@ -68,6 +68,7 @@ fun <T> Router(contextId: String, defaultRouting: T, children: @Composable() (Ba
     }
 }
 
+@Composable
 private fun <T> fetchBackStack(key: String, defaultElement: T, override: T?): BackStack<T> {
     val upstreamBundle = AmbientSavedInstanceState.current
     val onElementRemoved: (Int) -> Unit = { upstreamBundle.remove(key(it)) }


### PR DESCRIPTION
I am using snapshot version of compose, and this crashes without annotation