### PR TITLE
update to dev13

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Routing functionality for Jetpack Compose with back stack:
 - Can be integrated with automatic scoped `savedInstanceState` persistence
 - Supports routing based on deep links (POC impl)
 
-Compatible with Compose version **0.1.0-dev12**
+Compatible with Compose version **0.1.0-dev13**
 
 ## Sample apps
 

--- a/app-lifelike/build.gradle
+++ b/app-lifelike/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
 
     defaultConfig {
         applicationId "com.example.lifelike"
         minSdkVersion 24
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 
@@ -33,7 +33,8 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "0.1.0-dev09"
+        kotlinCompilerVersion "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
+        kotlinCompilerExtensionVersion "0.1.0-dev13"
     }
 }
 
@@ -41,13 +42,14 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.2.0'
-    implementation 'androidx.ui:ui-framework:0.1.0-dev09'
-    implementation 'androidx.ui:ui-layout:0.1.0-dev09'
-    implementation 'androidx.ui:ui-material:0.1.0-dev09'
-    implementation 'androidx.ui:ui-tooling:0.1.0-dev09'
-    implementation 'androidx.ui:ui-foundation:0.1.0-dev09'
-    implementation 'com.github.zsoltk:compose-router:0.9.0'
+    implementation 'androidx.core:core-ktx:1.3.0'
+    implementation 'androidx.ui:ui-core:0.1.0-dev13'
+    implementation 'androidx.ui:ui-layout:0.1.0-dev13'
+    implementation 'androidx.ui:ui-material:0.1.0-dev13'
+    implementation 'androidx.ui:ui-tooling:0.1.0-dev13'
+    implementation 'androidx.ui:ui-foundation:0.1.0-dev13'
+    //implementation 'com.github.zsoltk:compose-router:0.11.1'
+    implementation project(":router")
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app-lifelike/src/main/java/com/example/lifelike/DeepLink.kt
+++ b/app-lifelike/src/main/java/com/example/lifelike/DeepLink.kt
@@ -11,7 +11,7 @@ import com.example.lifelike.entity.User
 fun Intent.deepLinkRoute(): List<Any> =
     when (data?.host) {
         //  adb shell 'am start -a "android.intent.action.VIEW" -d "app-lifelike://go-to-profile?name=fake&phone=123123"'
-        "go-to-profile" -> parseProfileDeepLink(data)
+        "go-to-profile" -> parseProfileDeepLink(data!!)
         null -> emptyList()
         else -> emptyList<Any>().also {
             Log.e("compose-router", "Unexpected deep link: $data")

--- a/app-lifelike/src/main/java/com/example/lifelike/composable/loggedin/PhotosOfAlbum.kt
+++ b/app-lifelike/src/main/java/com/example/lifelike/composable/loggedin/PhotosOfAlbum.kt
@@ -1,18 +1,13 @@
 package com.example.lifelike.composable.loggedin
 
 import androidx.compose.Composable
+import androidx.ui.core.DensityAmbient
 import androidx.ui.core.Modifier
-import androidx.ui.foundation.Box
-import androidx.ui.foundation.Clickable
-import androidx.ui.foundation.Image
-import androidx.ui.foundation.Text
-import androidx.ui.foundation.VerticalScroller
-import androidx.ui.layout.Column
-import androidx.ui.layout.Table
-import androidx.ui.layout.TableColumnWidth
-import androidx.ui.layout.aspectRatio
-import androidx.ui.layout.fillMaxSize
-import androidx.ui.layout.padding
+import androidx.ui.core.WithConstraints
+import androidx.ui.foundation.*
+import androidx.ui.layout.*
+//import androidx.ui.layout.Table
+//import androidx.ui.layout.TableColumnWidth
 import androidx.ui.material.MaterialTheme
 import androidx.ui.res.imageResource
 import androidx.ui.tooling.preview.Preview
@@ -44,13 +39,13 @@ interface PhotosOfAlbum {
 
         @Composable
         fun AlbumView(album: Album, onPhotoSelected: (Photo) -> Unit) {
-            VerticalScroller {
+            //VerticalScroller {
                 Column {
                     AlbumTitle(album)
                     PhotoCount(album)
                     PhotoGrid(album = album, onPhotoSelected = onPhotoSelected)
                 }
-            }
+            //}
         }
 
         @Composable
@@ -84,8 +79,43 @@ interface PhotosOfAlbum {
             val image = imageResource(R.drawable.placeholder)
 
 
+            val photoRows =  mutableListOf<List<Photo>>()
+
+            for (i in album.photos.indices step cols) {
+                val row = mutableListOf<Photo>()
+                for (r in 0 until cols){
+                    if (i+r >= album.photos.size) break
+                    row.add(album.photos[i+r])
+                }
+                photoRows.add(row)
+            }
+
             Box(modifier = Modifier.padding(4.dp)) {
-                Table(columns = cols, columnWidth = { TableColumnWidth.Fraction(1.0f / cols) }) {
+                //scrolling fast may cause exception: https://issuetracker.google.com/issues/154653504
+                AdapterList(
+                        data = photoRows,
+                        itemCallback = { row ->
+                            WithConstraints {
+                                Row {
+                                    val w = with(DensityAmbient.current) { (constraints.maxWidth.toDp().value / cols).dp }
+                                    row.forEach { photo ->
+                                        Box(modifier = Modifier
+                                                .width(w)
+                                                .padding(4.dp)
+                                                .clickable(onClick = { onPhotoSelected(photo) })
+                                        ) {
+                                            Box(modifier = Modifier.aspectRatio(1f).fillMaxSize()) {
+                                                Image(image)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                )
+                /*Table layout was removed temporarily until we will make it available again with a refreshed API. (Id88a7)
+                https://developer.android.com/jetpack/androidx/releases/ui#0.1.0-dev11*/
+                /*Table(columns = cols, columnWidth = { TableColumnWidth.Fraction(1.0f / cols) }) {
                     for (i in 0..rows) {
                         tableRow {
                             val startIndex = i * cols
@@ -103,7 +133,7 @@ interface PhotosOfAlbum {
                             }
                         }
                     }
-                }
+                }*/
             }
         }
     }

--- a/app-lifelike/src/main/java/com/example/lifelike/composable/loggedin/PhotosOfAlbum.kt
+++ b/app-lifelike/src/main/java/com/example/lifelike/composable/loggedin/PhotosOfAlbum.kt
@@ -4,10 +4,17 @@ import androidx.compose.Composable
 import androidx.ui.core.DensityAmbient
 import androidx.ui.core.Modifier
 import androidx.ui.core.WithConstraints
-import androidx.ui.foundation.*
-import androidx.ui.layout.*
-//import androidx.ui.layout.Table
-//import androidx.ui.layout.TableColumnWidth
+import androidx.ui.foundation.AdapterList
+import androidx.ui.foundation.Box
+import androidx.ui.foundation.Image
+import androidx.ui.foundation.Text
+import androidx.ui.foundation.clickable
+import androidx.ui.layout.aspectRatio
+import androidx.ui.layout.Column
+import androidx.ui.layout.fillMaxSize
+import androidx.ui.layout.Row
+import androidx.ui.layout.padding
+import androidx.ui.layout.width
 import androidx.ui.material.MaterialTheme
 import androidx.ui.res.imageResource
 import androidx.ui.tooling.preview.Preview
@@ -39,13 +46,11 @@ interface PhotosOfAlbum {
 
         @Composable
         fun AlbumView(album: Album, onPhotoSelected: (Photo) -> Unit) {
-            //VerticalScroller {
-                Column {
-                    AlbumTitle(album)
-                    PhotoCount(album)
-                    PhotoGrid(album = album, onPhotoSelected = onPhotoSelected)
-                }
-            //}
+            Column {
+                AlbumTitle(album)
+                PhotoCount(album)
+                PhotoGrid(album = album, onPhotoSelected = onPhotoSelected)
+            }
         }
 
         @Composable
@@ -72,68 +77,30 @@ interface PhotosOfAlbum {
 
         @Composable
         fun PhotoGrid(album: Album, onPhotoSelected: (Photo) -> Unit) {
-            val nbPhotos = album.photos.size
-            val lastIndex = album.photos.lastIndex
             val cols = 4
-            val rows = nbPhotos / cols
             val image = imageResource(R.drawable.placeholder)
-
-
-            val photoRows =  mutableListOf<List<Photo>>()
-
-            for (i in album.photos.indices step cols) {
-                val row = mutableListOf<Photo>()
-                for (r in 0 until cols){
-                    if (i+r >= album.photos.size) break
-                    row.add(album.photos[i+r])
-                }
-                photoRows.add(row)
-            }
+            val photoRows =  album.photos.chunked(cols)
 
             Box(modifier = Modifier.padding(4.dp)) {
                 //scrolling fast may cause exception: https://issuetracker.google.com/issues/154653504
-                AdapterList(
-                        data = photoRows,
-                        itemCallback = { row ->
-                            WithConstraints {
-                                Row {
-                                    val w = with(DensityAmbient.current) { (constraints.maxWidth.toDp().value / cols).dp }
-                                    row.forEach { photo ->
-                                        Box(modifier = Modifier
-                                                .width(w)
-                                                .padding(4.dp)
-                                                .clickable(onClick = { onPhotoSelected(photo) })
-                                        ) {
-                                            Box(modifier = Modifier.aspectRatio(1f).fillMaxSize()) {
-                                                Image(image)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                )
-                /*Table layout was removed temporarily until we will make it available again with a refreshed API. (Id88a7)
-                https://developer.android.com/jetpack/androidx/releases/ui#0.1.0-dev11*/
-                /*Table(columns = cols, columnWidth = { TableColumnWidth.Fraction(1.0f / cols) }) {
-                    for (i in 0..rows) {
-                        tableRow {
-                            val startIndex = i * cols
-                            val maxIndex = (i + 1) * cols - 1
-                            val endIndex = if (maxIndex > lastIndex) lastIndex else maxIndex
-
-                            for (j in startIndex..endIndex) {
-                                Box(modifier = Modifier.padding(4.dp)) {
-                                    Clickable(onClick = { onPhotoSelected(album.photos[j]) }) {
-                                        Box(modifier = Modifier.aspectRatio(1f).fillMaxSize()) {
-                                            Image(image)
-                                        }
+                AdapterList(photoRows) { row ->
+                    WithConstraints {
+                        Row {
+                            val w = with(DensityAmbient.current) { (constraints.maxWidth.toDp().value / cols).dp }
+                            row.forEach { photo ->
+                                Box(modifier = Modifier
+                                        .width(w)
+                                        .padding(4.dp)
+                                        .clickable(onClick = { onPhotoSelected(photo) })
+                                ) {
+                                    Box(modifier = Modifier.aspectRatio(1f).fillMaxSize()) {
+                                        Image(image)
                                     }
                                 }
                             }
                         }
                     }
-                }*/
+                }
             }
         }
     }

--- a/app-nested-containers/build.gradle
+++ b/app-nested-containers/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
 
     defaultConfig {
         applicationId "com.example.nestedcontainers"
         minSdkVersion 24
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -33,7 +33,8 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "0.1.0-dev09"
+        kotlinCompilerVersion "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
+        kotlinCompilerExtensionVersion "0.1.0-dev12"
     }
 }
 
@@ -41,13 +42,13 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.2.0'
-    implementation 'androidx.ui:ui-framework:0.1.0-dev09'
-    implementation 'androidx.ui:ui-layout:0.1.0-dev09'
-    implementation 'androidx.ui:ui-material:0.1.0-dev09'
-    implementation 'androidx.ui:ui-tooling:0.1.0-dev09'
-    implementation 'androidx.ui:ui-foundation:0.1.0-dev09'
-    implementation 'com.github.zsoltk:compose-router:0.9.0'
+    implementation 'androidx.core:core-ktx:1.3.0'
+    implementation 'androidx.ui:ui-core:0.1.0-dev12'
+    implementation 'androidx.ui:ui-layout:0.1.0-dev12'
+    implementation 'androidx.ui:ui-material:0.1.0-dev12'
+    implementation 'androidx.ui:ui-tooling:0.1.0-dev12'
+    implementation 'androidx.ui:ui-foundation:0.1.0-dev12'
+    implementation 'com.github.zsoltk:compose-router:0.11.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app-nested-containers/build.gradle
+++ b/app-nested-containers/build.gradle
@@ -34,7 +34,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
-        kotlinCompilerExtensionVersion "0.1.0-dev12"
+        kotlinCompilerExtensionVersion "0.1.0-dev13"
     }
 }
 
@@ -43,12 +43,13 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.3.0'
-    implementation 'androidx.ui:ui-core:0.1.0-dev12'
-    implementation 'androidx.ui:ui-layout:0.1.0-dev12'
-    implementation 'androidx.ui:ui-material:0.1.0-dev12'
-    implementation 'androidx.ui:ui-tooling:0.1.0-dev12'
-    implementation 'androidx.ui:ui-foundation:0.1.0-dev12'
-    implementation 'com.github.zsoltk:compose-router:0.11.1'
+    implementation 'androidx.ui:ui-core:0.1.0-dev13'
+    implementation 'androidx.ui:ui-layout:0.1.0-dev13'
+    implementation 'androidx.ui:ui-material:0.1.0-dev13'
+    implementation 'androidx.ui:ui-tooling:0.1.0-dev13'
+    implementation 'androidx.ui:ui-foundation:0.1.0-dev13'
+    //implementation 'com.github.zsoltk:compose-router:0.11.1'
+    implementation project(":router")
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@
 
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:4.1.0-alpha10'
+            classpath 'com.android.tools.build:gradle:4.2.0-alpha01'
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
             // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat May 09 19:15:25 CEST 2020
+#Thu Jun 11 13:43:26 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-milestone-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/router/build.gradle
+++ b/router/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -34,7 +34,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
-        kotlinCompilerExtensionVersion "0.1.0-dev12"
+        kotlinCompilerExtensionVersion "0.1.0-dev13"
     }
     packagingOptions {
         excludes = []
@@ -46,11 +46,11 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.3.0'
-    implementation 'androidx.ui:ui-core:0.1.0-dev12'
-    implementation 'androidx.ui:ui-layout:0.1.0-dev12'
-    implementation 'androidx.ui:ui-material:0.1.0-dev12'
-    implementation 'androidx.ui:ui-tooling:0.1.0-dev12'
-    implementation 'androidx.ui:ui-foundation:0.1.0-dev12'
+    implementation 'androidx.ui:ui-core:0.1.0-dev13'
+    implementation 'androidx.ui:ui-layout:0.1.0-dev13'
+    implementation 'androidx.ui:ui-material:0.1.0-dev13'
+    implementation 'androidx.ui:ui-tooling:0.1.0-dev13'
+    implementation 'androidx.ui:ui-foundation:0.1.0-dev13'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'


### PR DESCRIPTION
Updates to dev13, update compile and target sdk to 30.

I know you did not want the samples to reference the router module directly. And it should instead reference an existing release. But after being forced to update gradle, the only way I could get the lifelike module to compile was to update it to dev13. Which meant it needed access to router built with dev13.

Also I couldn't get the nested sample to build using dev09 with the gradle update so I was able to update that one to dev12