### PR TITLE
Update to dev14.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Routing functionality for Jetpack Compose with back stack:
 - Can be integrated with automatic scoped `savedInstanceState` persistence
 - Supports routing based on deep links (POC impl)
 
-Compatible with Compose version **0.1.0-dev13**
+Compatible with Compose version **0.1.0-dev14**
 
 ## Sample apps
 

--- a/app-lifelike/build.gradle
+++ b/app-lifelike/build.gradle
@@ -34,7 +34,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
-        kotlinCompilerExtensionVersion "0.1.0-dev13"
+        kotlinCompilerExtensionVersion "0.1.0-dev14"
     }
 }
 
@@ -43,11 +43,11 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.3.0'
-    implementation 'androidx.ui:ui-core:0.1.0-dev13'
-    implementation 'androidx.ui:ui-layout:0.1.0-dev13'
-    implementation 'androidx.ui:ui-material:0.1.0-dev13'
-    implementation 'androidx.ui:ui-tooling:0.1.0-dev13'
-    implementation 'androidx.ui:ui-foundation:0.1.0-dev13'
+    implementation 'androidx.ui:ui-core:0.1.0-dev14'
+    implementation 'androidx.ui:ui-layout:0.1.0-dev14'
+    implementation 'androidx.ui:ui-material:0.1.0-dev14'
+    implementation 'androidx.ui:ui-tooling:0.1.0-dev14'
+    implementation 'androidx.ui:ui-foundation:0.1.0-dev14'
     //implementation 'com.github.zsoltk:compose-router:0.11.1'
     implementation project(":router")
     testImplementation 'junit:junit:4.12'

--- a/app-lifelike/src/main/java/com/example/lifelike/composable/loggedin/PhotosOfAlbum.kt
+++ b/app-lifelike/src/main/java/com/example/lifelike/composable/loggedin/PhotosOfAlbum.kt
@@ -9,6 +9,7 @@ import androidx.ui.foundation.Box
 import androidx.ui.foundation.Image
 import androidx.ui.foundation.Text
 import androidx.ui.foundation.clickable
+import androidx.ui.foundation.lazy.LazyColumnItems
 import androidx.ui.layout.aspectRatio
 import androidx.ui.layout.Column
 import androidx.ui.layout.fillMaxSize
@@ -82,8 +83,7 @@ interface PhotosOfAlbum {
             val photoRows =  album.photos.chunked(cols)
 
             Box(modifier = Modifier.padding(4.dp)) {
-                //scrolling fast may cause exception: https://issuetracker.google.com/issues/154653504
-                AdapterList(photoRows) { row ->
+                LazyColumnItems(photoRows) { row ->
                     WithConstraints {
                         Row {
                             val w = with(DensityAmbient.current) { (constraints.maxWidth.toDp().value / cols).dp }

--- a/app-lifelike/src/main/java/com/example/lifelike/entity/User.kt
+++ b/app-lifelike/src/main/java/com/example/lifelike/entity/User.kt
@@ -1,9 +1,14 @@
 package com.example.lifelike.entity
 
-import androidx.compose.Model
+import androidx.compose.getValue
+import androidx.compose.mutableStateOf
+import androidx.compose.setValue
 
-@Model
+
 class User(
-    var name: String,
-    var phone: String
-)
+    name: String,
+    phone: String
+){
+    var name by mutableStateOf(name)
+    var phone by mutableStateOf(phone)
+}

--- a/app-nested-containers/build.gradle
+++ b/app-nested-containers/build.gradle
@@ -34,7 +34,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
-        kotlinCompilerExtensionVersion "0.1.0-dev13"
+        kotlinCompilerExtensionVersion "0.1.0-dev14"
     }
 }
 
@@ -43,11 +43,11 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.3.0'
-    implementation 'androidx.ui:ui-core:0.1.0-dev13'
-    implementation 'androidx.ui:ui-layout:0.1.0-dev13'
-    implementation 'androidx.ui:ui-material:0.1.0-dev13'
-    implementation 'androidx.ui:ui-tooling:0.1.0-dev13'
-    implementation 'androidx.ui:ui-foundation:0.1.0-dev13'
+    implementation 'androidx.ui:ui-core:0.1.0-dev14'
+    implementation 'androidx.ui:ui-layout:0.1.0-dev14'
+    implementation 'androidx.ui:ui-material:0.1.0-dev14'
+    implementation 'androidx.ui:ui-tooling:0.1.0-dev14'
+    implementation 'androidx.ui:ui-foundation:0.1.0-dev14'
     //implementation 'com.github.zsoltk:compose-router:0.11.1'
     implementation project(":router")
     testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@
 
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:4.2.0-alpha01'
+            classpath 'com.android.tools.build:gradle:4.2.0-alpha02'
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
             // NOTE: Do not place your application dependencies here; they belong

--- a/router/build.gradle
+++ b/router/build.gradle
@@ -34,7 +34,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
-        kotlinCompilerExtensionVersion "0.1.0-dev13"
+        kotlinCompilerExtensionVersion "0.1.0-dev14"
     }
     packagingOptions {
         excludes = []
@@ -46,11 +46,11 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.3.0'
-    implementation 'androidx.ui:ui-core:0.1.0-dev13'
-    implementation 'androidx.ui:ui-layout:0.1.0-dev13'
-    implementation 'androidx.ui:ui-material:0.1.0-dev13'
-    implementation 'androidx.ui:ui-tooling:0.1.0-dev13'
-    implementation 'androidx.ui:ui-foundation:0.1.0-dev13'
+    implementation 'androidx.ui:ui-core:0.1.0-dev14'
+    implementation 'androidx.ui:ui-layout:0.1.0-dev14'
+    implementation 'androidx.ui:ui-material:0.1.0-dev14'
+    implementation 'androidx.ui:ui-tooling:0.1.0-dev14'
+    implementation 'androidx.ui:ui-foundation:0.1.0-dev14'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/router/src/main/java/com/github/zsoltk/compose/router/BackStack.kt
+++ b/router/src/main/java/com/github/zsoltk/compose/router/BackStack.kt
@@ -1,13 +1,15 @@
 package com.github.zsoltk.compose.router
 
-import androidx.compose.Model
+import androidx.compose.getValue
+import androidx.compose.mutableStateOf
+import androidx.compose.setValue
 
-@Model
+
 class BackStack<T> internal constructor(
     initialElement: T,
     private var onElementRemoved: ((Int) -> Unit)
 ) {
-    private var elements = listOf(initialElement)
+    private var elements  by mutableStateOf(listOf(initialElement))
 
     val lastIndex: Int
         get() = elements.lastIndex


### PR DESCRIPTION
Removes use of depreciated @Model using [mutableStateOf method](https://developer.android.com/jetpack/androidx/releases/ui#0.1.0-dev12) 
AdapterList -> LazyColumnItems. Remove comment about fixed exception