### PR TITLE
Fix jitpack rebuild

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,17 +30,14 @@ jobs:
           java-version: 11
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Cache Gradle Caches
-        uses: actions/cache@v1
+      - name: Cache Gradle Files
+        uses: actions/cache@v2
         with:
-          path: ~/.gradle/caches/
-          key: cache-gradle-cache
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper/
-          key: cache-gradle-wrapper
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle
       - name: Run Gradle tasks
-        run: ./gradlew build --continue
+        run: ./gradlew build check --continue
       - name: Stop Gradle
         run: ./gradlew --stop


### PR DESCRIPTION
I think we just need to update the tags. say `0.24.1` which is a SemVer compatible.